### PR TITLE
Fix off by one in AChoir "/DRV:" check

### DIFF
--- a/AChoir.cpp
+++ b/AChoir.cpp
@@ -1019,7 +1019,7 @@ int main(int argc, char *argv[])
       iRunMode = 3;
     }
     else
-    if (strnicmp(argv[i], "/DRV:", 4) == 0)
+    if (strnicmp(argv[i], "/DRV:", 5) == 0)
     {
       if ((argv[i][6] == ':') && (strlen(argv[i]) == 7))
       {


### PR DESCRIPTION
The `"/DRV:"` string literal has a length of 5 and the `strnicmp(argv[i], "/DRV:", 4)` call incorrectly misses/doesn't match the `:` character.